### PR TITLE
Added convenient creation methods to `NSCollectionLayoutSize`

### DIFF
--- a/Sources/UIKitEssentials/Extensions/NSCollectionLayoutSize+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/NSCollectionLayoutSize+Extension.swift
@@ -1,0 +1,34 @@
+//
+//  NSCollectionLayoutSize+Extension.swift
+//  
+//
+//  Created by Yusaku Nishi on 2022/10/02.
+//
+
+import UIKit
+
+@available(iOS 13, tvOS 13, *)
+extension NSCollectionLayoutSize {
+    
+    /// Creates a size that fills the containing group.
+    public static var full: Self {
+        .init(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+    }
+    
+    /// Creates a size that is computed as a fraction of the width and height of the containing group.
+    public static func fractional(width: CGFloat, height: CGFloat) -> Self {
+        .init(widthDimension: .fractionalWidth(width), heightDimension: .fractionalHeight(height))
+    }
+    
+    /// Creates a size with estimated point values.
+    ///
+    /// The final size is determined when the content is rendered.
+    public static func estimated(width: CGFloat, height: CGFloat) -> Self {
+        .init(widthDimension: .estimated(width), heightDimension: .estimated(height))
+    }
+    
+    /// Creates a size with absolute point values.
+    public static func absolute(width: CGFloat, height: CGFloat) -> Self {
+        .init(widthDimension: .absolute(width), heightDimension: .absolute(height))
+    }
+}

--- a/Tests/UIKitEssentialsTests/NSCollectionLayoutSizeExtensionTests.swift
+++ b/Tests/UIKitEssentialsTests/NSCollectionLayoutSizeExtensionTests.swift
@@ -1,0 +1,46 @@
+//
+//  NSCollectionLayoutSizeExtensionTests.swift
+//  
+//
+//  Created by Yusaku Nishi on 2023/03/11.
+//
+
+import XCTest
+@testable import UIKitEssentials
+
+final class NSCollectionLayoutSizeExtensionTests: XCTestCase {
+    
+    func testCreationMethods() throws {
+        guard #available(iOS 13, tvOS 13, *) else {
+            throw XCTSkip("This test case requires")
+        }
+        XCTAssertEqual(
+            NSCollectionLayoutSize.full,
+            NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .fractionalHeight(1)
+            )
+        )
+        XCTAssertEqual(
+            NSCollectionLayoutSize.fractional(width: 0.3, height: 0.5),
+            NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(0.3),
+                heightDimension: .fractionalHeight(0.5)
+            )
+        )
+        XCTAssertEqual(
+            NSCollectionLayoutSize.estimated(width: 100, height: 200),
+            NSCollectionLayoutSize(
+                widthDimension: .estimated(100),
+                heightDimension: .estimated(200)
+            )
+        )
+        XCTAssertEqual(
+            NSCollectionLayoutSize.absolute(width: 300, height: 400),
+            NSCollectionLayoutSize(
+                widthDimension: .absolute(300),
+                heightDimension: .absolute(400)
+            )
+        )
+    }
+}


### PR DESCRIPTION
# Features
- Added convenient creation methods to `NSCollectionLayoutSize`.
  - `full`
  - `fractional(width:height:)`
  - `estimated(width:height:)`
  - `absolute(width:height:)`