### PR TITLE
Added deselection methods

### DIFF
--- a/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
@@ -9,7 +9,20 @@ import UIKit
 
 extension UICollectionView {
     
-    /// Deselects the selected items using the transition coordinator.
+    /// Deselects selected items.
+    ///
+    /// If the `allowsSelection` property is `false`, calling this method has no effect.
+    /// This method does not cause any selection-related delegate methods to be called.
+    ///
+    /// - Parameter animated: Specify `true` to animate the change in the selection or `false` to make the change without animating it.
+    public func deselectSelectedItems(animated: Bool) {
+        guard let indexPathsForSelectedItems else { return }
+        for indexPathForSelectedItem in indexPathsForSelectedItems {
+            deselectItem(at: indexPathForSelectedItem, animated: animated)
+        }
+    }
+    
+    /// Deselects selected items using the transition coordinator.
     ///
     /// Typically, you can use this method in `viewWillAppear` of the view controller:
     ///

--- a/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
@@ -46,22 +46,18 @@ extension UICollectionView {
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
     public func deselectSelectedItems(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                       animated: Bool) {
-        guard let indexPathsForSelectedItems = indexPathsForSelectedItems else { return }
-        func deselectSelectedItems() {
-            for indexPathForSelectedItem in indexPathsForSelectedItems {
-                deselectItem(at: indexPathForSelectedItem, animated: animated)
-            }
-        }
-        guard let transitionCoordinator = transitionCoordinator else {
-            deselectSelectedItems()
+        guard let transitionCoordinator else {
+            deselectSelectedItems(animated: animated)
             return
         }
-        transitionCoordinator.animate(alongsideTransition: { _ in
-            deselectSelectedItems()
+        transitionCoordinator.animate(alongsideTransition: { [weak self] _ in
+            self?.deselectSelectedItems(animated: animated)
         }, completion: { [weak self] context in
+            guard let self = self,
+                  let indexPathsForSelectedItems = self.indexPathsForSelectedItems else { return }
             if context.isCancelled {
                 for indexPathForSelectedItem in indexPathsForSelectedItems {
-                    self?.selectItem(at: indexPathForSelectedItem, animated: animated, scrollPosition: [])
+                    self.selectItem(at: indexPathForSelectedItem, animated: animated, scrollPosition: [])
                 }
             }
         })

--- a/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UICollectionView {
     
-    /// Deselects selected items.
+    /// Deselects all selected items.
     ///
     /// If the `allowsSelection` property is `false`, calling this method has no effect.
     /// This method does not cause any selection-related delegate methods to be called.
@@ -22,7 +22,10 @@ extension UICollectionView {
         }
     }
     
-    /// Deselects selected items using the transition coordinator.
+    /// Deselects all selected items using the transition coordinator.
+    ///
+    /// If the `allowsSelection` property is `false`, calling this method has no effect.
+    /// This method does not cause any selection-related delegate methods to be called.
     ///
     /// Typically, you can use this method in `viewWillAppear` of the view controller:
     ///

--- a/Sources/UIKitEssentials/Extensions/UIEdgeInsets+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UIEdgeInsets+Extension.swift
@@ -9,6 +9,10 @@ import UIKit
 
 extension UIEdgeInsets {
     
+    /// Creates an edge insets structure.
+    /// - Parameters:
+    ///   - vertical: Insets on the top and the bottom of an object.
+    ///   - horizontal: Insets on the left and the right of an object.
     @inlinable
     public init(vertical: CGFloat, horizontal: CGFloat) {
         self.init(top: vertical, left: horizontal, bottom: vertical, right: horizontal)

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -26,6 +26,11 @@ extension UITableView {
     
     /// Deselects the selected row using the transition coordinator.
     ///
+    /// Calling this method doesn’t cause the delegate to receive a `tableView(_:willDeselectRowAt:)` or `tableView(_:didDeselectRowAt:)` message,
+    /// nor does it send `selectionDidChangeNotification` notifications to observers.
+    ///
+    /// Calling this method doesn’t cause any scrolling to the deselected row.
+    ///
     /// Typically, you can use this method in `viewWillAppear` of the view controller:
     ///
     /// ```

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -24,6 +24,52 @@ extension UITableView {
         }
     }
     
+    /// Deselects all selected rows using the transition coordinator.
+    ///
+    /// Calling this method doesn’t cause the delegate to receive a `tableView(_:willDeselectRowAt:)` or `tableView(_:didDeselectRowAt:)` message,
+    /// nor does it send `selectionDidChangeNotification` notifications to observers.
+    ///
+    /// Calling this method doesn’t cause any scrolling to deselected rows.
+    ///
+    /// Typically, you can use this method in `viewWillAppear` of the view controller:
+    ///
+    /// ```
+    /// class ViewController: UIViewController {
+    ///
+    ///     override func viewWillAppear(_ animated: Bool) {
+    ///         super.viewWillAppear(animated)
+    ///
+    ///         tableView.deselectSelectedRows(with: transitionCoordinator,
+    ///                                        animated: animated)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// If the animation is cancelled, rows will be reselected.
+    ///
+    /// - Parameters:
+    ///   - transitionCoordinator: A transition coordinator used to animate the deselection.
+    ///                            If `nil`, the deselection will be done with normal animation.
+    ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
+    public func deselectSelectedRows(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
+                                     animated: Bool) {
+        guard let transitionCoordinator = transitionCoordinator else {
+            deselectSelectedRows(animated: animated)
+            return
+        }
+        transitionCoordinator.animate(alongsideTransition: { [weak self] _ in
+            self?.deselectSelectedRows(animated: animated)
+        }, completion: { [weak self] context in
+            guard let self,
+                  let indexPathsForSelectedRows = self.indexPathsForSelectedRows else { return }
+            if context.isCancelled {
+                for indexPathForSelectedRow in indexPathsForSelectedRows {
+                    self.selectRow(at: indexPathForSelectedRow, animated: animated, scrollPosition: .none)
+                }
+            }
+        })
+    }
+    
     /// Deselects the selected row using the transition coordinator.
     ///
     /// Calling this method doesn’t cause the delegate to receive a `tableView(_:willDeselectRowAt:)` or `tableView(_:didDeselectRowAt:)` message,
@@ -51,6 +97,7 @@ extension UITableView {
     ///   - transitionCoordinator: A transition coordinator used to animate the deselection.
     ///                            If `nil`, the deselection will be done with normal animation.
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
+    @available(*, deprecated, message: "Use deselectSelectedRows(with:animated:) instead.")
     public func deselectSelectedRow(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                     animated: Bool) {
         guard let indexPathForSelectedRow = indexPathForSelectedRow else { return }

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -9,6 +9,21 @@ import UIKit
 
 extension UITableView {
     
+    /// Deselects all selected rows, with an option to animate the deselection.
+    ///
+    /// Calling this method doesn’t cause the delegate to receive a `tableView(_:willDeselectRowAt:)` or `tableView(_:didDeselectRowAt:)` message,
+    /// nor does it send `selectionDidChangeNotification` notifications to observers.
+    ///
+    /// Calling this method doesn’t cause any scrolling to deselected rows.
+    ///
+    /// - Parameter animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
+    public func deselectSelectedRows(animated: Bool) {
+        guard let indexPathsForSelectedRows else { return }
+        for indexPathForSelectedRow in indexPathsForSelectedRows {
+            deselectRow(at: indexPathForSelectedRow, animated: animated)
+        }
+    }
+    
     /// Deselects the selected row using the transition coordinator.
     ///
     /// Typically, you can use this method in `viewWillAppear` of the view controller:


### PR DESCRIPTION
# Features
- Added `UITableView.deselectSelectedRows(animated:)` method.
- Added `UITableView.deselectSelectedRows(with:animated:)` method.
- Added `UICollectionView.deselectSelectedItems(animated:)` method.

# Improvements
- Improved documentation comments.

# Deprecations
- Deprecated `UITableView.deselectSelectedRow(with:animated:)` method. This method deselects only one row so it doesn't work expectedly when multiple rows are selected.