### PR TITLE
Fixed cell deselection

### DIFF
--- a/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
@@ -50,7 +50,7 @@ extension UICollectionView {
     public func deselectSelectedItems(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                       animated: Bool) {
         guard let indexPathsForSelectedItems else { return }
-        guard let transitionCoordinator else {
+        guard let transitionCoordinator, animated else {
             deselectSelectedItems(animated: animated)
             return
         }

--- a/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
@@ -47,7 +47,7 @@ extension UICollectionView {
     ///   - transitionCoordinator: A transition coordinator used to animate the deselection.
     ///                            If `nil`, the deselection will be done with normal animation.
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
-    public func deselectSelectedItems(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
+    public func deselectSelectedItems(with transitionCoordinator: (any UIViewControllerTransitionCoordinator)?,
                                       animated: Bool) {
         guard let indexPathsForSelectedItems else { return }
         guard let transitionCoordinator, animated else {

--- a/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UICollectionView+Extension.swift
@@ -49,6 +49,7 @@ extension UICollectionView {
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
     public func deselectSelectedItems(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                       animated: Bool) {
+        guard let indexPathsForSelectedItems else { return }
         guard let transitionCoordinator else {
             deselectSelectedItems(animated: animated)
             return
@@ -56,9 +57,9 @@ extension UICollectionView {
         transitionCoordinator.animate(alongsideTransition: { [weak self] _ in
             self?.deselectSelectedItems(animated: animated)
         }, completion: { [weak self] context in
-            guard let self = self,
-                  let indexPathsForSelectedItems = self.indexPathsForSelectedItems else { return }
+            guard let self else { return }
             if context.isCancelled {
+                // Reselect items
                 for indexPathForSelectedItem in indexPathsForSelectedItems {
                     self.selectItem(at: indexPathForSelectedItem, animated: animated, scrollPosition: [])
                 }

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -101,8 +101,8 @@ extension UITableView {
     @available(*, deprecated, message: "Use deselectSelectedRows(with:animated:) instead.")
     public func deselectSelectedRow(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                     animated: Bool) {
-        guard let indexPathForSelectedRow = indexPathForSelectedRow else { return }
-        guard let transitionCoordinator = transitionCoordinator else {
+        guard let indexPathForSelectedRow else { return }
+        guard let transitionCoordinator else {
             deselectRow(at: indexPathForSelectedRow, animated: animated)
             return
         }

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -54,7 +54,7 @@ extension UITableView {
     public func deselectSelectedRows(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                      animated: Bool) {
         guard let indexPathsForSelectedRows else { return }
-        guard let transitionCoordinator else {
+        guard let transitionCoordinator, animated else {
             deselectSelectedRows(animated: animated)
             return
         }

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -51,7 +51,7 @@ extension UITableView {
     ///   - transitionCoordinator: A transition coordinator used to animate the deselection.
     ///                            If `nil`, the deselection will be done with normal animation.
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
-    public func deselectSelectedRows(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
+    public func deselectSelectedRows(with transitionCoordinator: (any UIViewControllerTransitionCoordinator)?,
                                      animated: Bool) {
         guard let indexPathsForSelectedRows else { return }
         guard let transitionCoordinator, animated else {
@@ -99,7 +99,7 @@ extension UITableView {
     ///                            If `nil`, the deselection will be done with normal animation.
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
     @available(*, deprecated, message: "Use deselectSelectedRows(with:animated:) instead.")
-    public func deselectSelectedRow(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
+    public func deselectSelectedRow(with transitionCoordinator: (any UIViewControllerTransitionCoordinator)?,
                                     animated: Bool) {
         guard let indexPathForSelectedRow else { return }
         guard let transitionCoordinator else {

--- a/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
+++ b/Sources/UIKitEssentials/Extensions/UITableView+Extension.swift
@@ -53,16 +53,17 @@ extension UITableView {
     ///   - animated: `true` if you want to animate the deselection, and `false` if the change should be immediate.
     public func deselectSelectedRows(with transitionCoordinator: UIViewControllerTransitionCoordinator?,
                                      animated: Bool) {
-        guard let transitionCoordinator = transitionCoordinator else {
+        guard let indexPathsForSelectedRows else { return }
+        guard let transitionCoordinator else {
             deselectSelectedRows(animated: animated)
             return
         }
         transitionCoordinator.animate(alongsideTransition: { [weak self] _ in
             self?.deselectSelectedRows(animated: animated)
         }, completion: { [weak self] context in
-            guard let self,
-                  let indexPathsForSelectedRows = self.indexPathsForSelectedRows else { return }
+            guard let self else { return }
             if context.isCancelled {
+                // Reselect rows
                 for indexPathForSelectedRow in indexPathsForSelectedRows {
                     self.selectRow(at: indexPathForSelectedRow, animated: animated, scrollPosition: .none)
                 }


### PR DESCRIPTION
# Fixed bugs
- Fixed a bug that failed to reselect cells when canceling transitions.
- Fixed to disable animation when `animated` is `false`.

# Maintenance
- Marked existential types with `any`.
- Refactored optional binding.